### PR TITLE
Fix typos in GUI and server descriptions

### DIFF
--- a/_data/guis.yml
+++ b/_data/guis.yml
@@ -21,7 +21,7 @@ items:
   - title: Cutechess
     description: |-
       Cutechess mainly a chess (variant) engine tournament manager, with both a command line and a graphical user interface.
-      Also supportd game play against engines, but does not have analysis features.
+      Also supports game play against engines, but does not have analysis features.
     link: https://github.com/cutechess/cutechess
     link_text: Download Cutechess
     tags: Chess,Shogi,Makruk,Crazyhouse,Atomic,Antichess,Horde,Three-Check,King of the Hill,Racing Kings,S-Chess,Berolina

--- a/_data/servers.yml
+++ b/_data/servers.yml
@@ -46,7 +46,7 @@ items:
     github: Mind-Sports-Games/lila
   - title: PlayOk
     description: |-
-      PlayOk is a free abstract strategy strategy game website supporting a few regional chess variants.
+      PlayOk is a free abstract strategy game website supporting a few regional chess variants.
       It has quite many players, but a rather dated interface.
     link: https://www.playok.com
     link_text: Play


### PR DESCRIPTION
- guis.yml: 'supportd' -> 'supports' in Cutechess description.
- servers.yml: remove duplicated word in PlayOk description.
- No functional changes.