### PR TITLE
Run calendar workflow on PRs and avoid committing PR updates

### DIFF
--- a/.github/workflows/calendar.yml
+++ b/.github/workflows/calendar.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+  pull_request:
 
 jobs:
   update-tournaments:
@@ -30,8 +31,29 @@ jobs:
         run: |
           python _scripts/update_tournaments.py
 
+      - name: Add tournaments diff to summary (pull requests only)
+        if: github.event_name == 'pull_request'
+        run: |
+          diff_output=$(git diff -- _data/tournaments.tsv)
+          if [ -z "$diff_output" ]; then
+            {
+              echo "## Tournament list diff"
+              echo
+              echo "No changes in \\`_data/tournaments.tsv\\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Tournament list diff"
+              echo
+              echo '```diff'
+              echo "$diff_output"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       # Commit all changed files back to the repository
       - uses: stefanzweifel/git-auto-commit-action@v7
+        if: github.event_name != 'pull_request'
         with:
           commit_message: Update tournaments
           file_pattern: '*.tsv'


### PR DESCRIPTION
### Motivation
- Allow the tournament updater to run for `pull_request` events so reviewers can see what would change while ensuring PR runs never push commits back to the branch.

### Description
- Add a `pull_request` trigger to `.github/workflows/calendar.yml`, add a pull-request-only step that writes the `git diff -- _data/tournaments.tsv` output into `$GITHUB_STEP_SUMMARY`, and gate the auto-commit action with `if: github.event_name != 'pull_request'` so commits only occur for non-PR runs.

### Testing
- Verified the workflow file changes with `git diff -- .github/workflows/calendar.yml`, inspected the updated file with `nl -ba .github/workflows/calendar.yml`, and confirmed the working tree with `git status --short`, all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4915f038832b9ca6592e90d84346)