### PR TITLE
Enable link verification workflow for pull requests

### DIFF
--- a/.github/workflows/verify-links.yml
+++ b/.github/workflows/verify-links.yml
@@ -1,6 +1,10 @@
 name: Verify External Links
 
 on:
+  # Run on pull requests targeting main
+  pull_request:
+    branches: [ main ]
+
   # Run on the first day of every month at 00:00 UTC
   schedule:
     - cron: '0 0 1 * *'


### PR DESCRIPTION
### Motivation
- Run the external link verification on pull requests targeting `main` so broken external links are detected before changes are merged and complement the existing monthly checks.

### Description
- Add a `pull_request` trigger (branches: [ main ]) to `.github/workflows/verify-links.yml` so the `verify-links` job runs on PRs.
- Preserve the existing monthly `schedule` and the `workflow_dispatch` manual trigger and leave the job steps unchanged.

### Testing
- Validated the updated workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/verify-links.yml'); puts 'YAML OK'"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4b289e1c832ba2eff244a37923de)